### PR TITLE
PeerID & Multiaddr Interop Tests

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -32,16 +32,16 @@ let package = Package(
         // Dependencies declare other packages that this package depends on.
 
         // Swift NIO for all things networking
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.0.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", .upToNextMajor(from: "2.0.0")),
 
         // LibP2P Peer Identities
-        .package(url: "https://github.com/swift-libp2p/swift-peer-id.git", from: "0.0.1"),
+        .package(url: "https://github.com/swift-libp2p/swift-peer-id.git", .upToNextMinor(from: "0.1.0")),
 
         // LibP2P Multiaddr
-        .package(url: "https://github.com/swift-libp2p/swift-multiaddr.git", from: "0.0.1"),
+        .package(url: "https://github.com/swift-libp2p/swift-multiaddr.git", .upToNextMinor(from: "0.0.1")),
 
         // Logging
-        .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
+        .package(url: "https://github.com/apple/swift-log.git", .upToNextMajor(from: "1.0.0")),
 
         // Swift Protobuf
         //.package(url: "https://github.com/apple/swift-protobuf.git", .exact("1.19.0")),

--- a/Sources/LibP2PCore/Peer/Peer.swift
+++ b/Sources/LibP2PCore/Peer/Peer.swift
@@ -44,22 +44,12 @@ public struct PeerInfo {
     }
 }
 
-extension PeerID {
-    func extractPublicKey() -> PeerID? {
-        if self.type == .isPublic || self.type == .isPrivate { return self }
-        switch self.keyPair?.keyType {
-        case .ed25519:
-            return try? PeerID(cid: self.cidString)
-        default:
-            return nil
+extension Multiaddr {
+    // TODO: Rename this to getPeerID once https://github.com/swift-libp2p/swift-multiaddr/issues/14 is addressed
+    func getPeerIDActual() throws -> PeerID {
+        guard let cid = self.getPeerID() else {
+            throw NSError(domain: "No CID present in Multiaddr", code: 0)
         }
+        return try PeerID(cid: cid)
     }
 }
-
-//extension Multiaddr {
-//    func getPeerID() -> PeerID {
-//        self.
-//    }
-//}
-
-//extension PeerID.Key.RawPublicKey: PublicKey { }

--- a/Sources/LibP2PCore/Routing/Routing.swift
+++ b/Sources/LibP2PCore/Routing/Routing.swift
@@ -103,7 +103,7 @@ func getPublicKey(_ store: ValueStore, peer: PeerID, on: EventLoop) -> EventLoop
 
     /// TODO: Implement ValueStore protocol ...
     return on.makeFailedFuture(RoutingErrors.notFound)
-    
+
     //let key = keyForPublicKey(id: peer)
     //return store.getValue(key: key).flatMapThrowing { pkval -> PublicKey in
     //    try PublicKey(fromMarshaledValue: pkval)

--- a/Sources/LibP2PCore/Routing/Routing.swift
+++ b/Sources/LibP2PCore/Routing/Routing.swift
@@ -91,9 +91,9 @@ func keyForPublicKey(id: PeerID) -> String {
 }
 
 func getPublicKey(_ store: ValueStore, peer: PeerID, on: EventLoop) -> EventLoopFuture<PeerID> {
-    /// extractPublicKey will simply check if the Peer has a pubkey in it's keypair or if the pubkey is embedded in it's ID (in the case of Ed25519 keys)
-    if let pubKey = peer.extractPublicKey() {
-        return on.makeSucceededFuture(pubKey)
+    /// If the PeerID has a public key, just return it
+    if peer.keyPair?.publicKey != nil {
+        return on.makeSucceededFuture(peer)
     }
 
     /// If we have a DHT as our routing system, use optimized fetcher
@@ -101,10 +101,10 @@ func getPublicKey(_ store: ValueStore, peer: PeerID, on: EventLoop) -> EventLoop
         return dht.getPublicKey(peerID: peer.cidString)
     }
 
-    let key = keyForPublicKey(id: peer)
-
+    /// TODO: Implement ValueStore protocol ...
     return on.makeFailedFuture(RoutingErrors.notFound)
-    /// TODO: Figure out how to handle this...
+    
+    //let key = keyForPublicKey(id: peer)
     //return store.getValue(key: key).flatMapThrowing { pkval -> PublicKey in
     //    try PublicKey(fromMarshaledValue: pkval)
     //}

--- a/Tests/LibP2PCoreTests/MultiaddrPeerIDTests.swift
+++ b/Tests/LibP2PCoreTests/MultiaddrPeerIDTests.swift
@@ -19,7 +19,7 @@ import XCTest
 // These Multiaddr <-> PeerID tests are located here in swift-libp2p-core because
 // this is the first package in our stack that depends on the two of them
 final class MultiaddrPeerIDTests: XCTestCase {
-    
+
     // Make sure we can extract a PeerID from a Multiaddr
     func testGetPeerID() throws {
         // B58 String
@@ -35,16 +35,16 @@ final class MultiaddrPeerIDTests: XCTestCase {
             "/dnsaddr/bootstrap.libp2p.io/p2p/bafzbeiagwnqiviaae5aet2zivwhhsorg75x2wka2pu55o7grr23ulx5kxm"
         )
         let peerID3 = try ma3.getPeerIDActual()
-        
+
         XCTAssertEqual(peerID1, peerID2)
         XCTAssertEqual(peerID1, peerID3)
-        
+
         // Embedded Public Key
         let ma4 = try Multiaddr("/dnsaddr/bootstrap.libp2p.io/p2p/12D3KooWAfPDpPRRRBrmqy9is2zjU5srQ4hKuZitiGmh4NTTpS2d")
         let peerID4 = try ma4.getPeerIDActual()
-        
+
         XCTAssertEqual(peerID4.type, .isPublic)
-        
+
         // Throw when no PeerID is present
         XCTAssertThrowsError(try Multiaddr("/dnsaddr/bootstrap.libp2p.io/").getPeerIDActual())
     }

--- a/Tests/LibP2PCoreTests/MultiaddrPeerIDTests.swift
+++ b/Tests/LibP2PCoreTests/MultiaddrPeerIDTests.swift
@@ -1,0 +1,72 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-libp2p open source project
+//
+// Copyright (c) 2022-2025 swift-libp2p project authors
+// Licensed under MIT
+//
+// See LICENSE for license information
+// See CONTRIBUTORS for the list of swift-libp2p project authors
+//
+// SPDX-License-Identifier: MIT
+//
+//===----------------------------------------------------------------------===//
+
+import XCTest
+
+@testable import LibP2PCore
+
+// These Multiaddr <-> PeerID tests are located here in swift-libp2p-core because
+// this is the first package in our stack that depends on the two of them
+final class MultiaddrPeerIDTests: XCTestCase {
+    
+    // Make sure we can extract a PeerID from a Multiaddr
+    func testGetPeerID() throws {
+        // B58 String
+        let ma1 = try Multiaddr("/dnsaddr/bootstrap.libp2p.io/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN")
+        let peerID1 = try ma1.getPeerIDActual()
+
+        // B58 String
+        let ma2 = try Multiaddr("/ip4/139.178.91.71/tcp/4001/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN")
+        let peerID2 = try ma2.getPeerIDActual()
+
+        // CID String
+        let ma3 = try Multiaddr(
+            "/dnsaddr/bootstrap.libp2p.io/p2p/bafzbeiagwnqiviaae5aet2zivwhhsorg75x2wka2pu55o7grr23ulx5kxm"
+        )
+        let peerID3 = try ma3.getPeerIDActual()
+        
+        XCTAssertEqual(peerID1, peerID2)
+        XCTAssertEqual(peerID1, peerID3)
+        
+        // Embedded Public Key
+        let ma4 = try Multiaddr("/dnsaddr/bootstrap.libp2p.io/p2p/12D3KooWAfPDpPRRRBrmqy9is2zjU5srQ4hKuZitiGmh4NTTpS2d")
+        let peerID4 = try ma4.getPeerIDActual()
+        
+        XCTAssertEqual(peerID4.type, .isPublic)
+        
+        // Throw when no PeerID is present
+        XCTAssertThrowsError(try Multiaddr("/dnsaddr/bootstrap.libp2p.io/").getPeerIDActual())
+    }
+
+    func testGetPeerIDEmbeddedEd25519PublicKey() throws {
+        let ma1 = try Multiaddr("/dnsaddr/bootstrap.libp2p.io/p2p/12D3KooWAfPDpPRRRBrmqy9is2zjU5srQ4hKuZitiGmh4NTTpS2d")
+
+        let embeddedKeyInBytes = try BaseEncoding.decode(ma1.getPeerID()!, as: .base58btc)
+        let peerID1 = try PeerID(fromBytesID: embeddedKeyInBytes.data.bytes)
+
+        let ma2 = try Multiaddr("/dnsaddr/bootstrap.libp2p.io/p2p/12D3KooWAfPDpPRRRBrmqy9is2zjU5srQ4hKuZitiGmh4NTTpS2d")
+        let peerID2 = try ma2.getPeerIDActual()
+
+        XCTAssertEqual(peerID1, peerID2)
+        XCTAssertEqual(peerID1.type, .isPublic)
+        XCTAssertEqual(peerID2.type, .isPublic)
+
+        let ma3 = try Multiaddr("/ip4/139.178.91.71/tcp/4001/p2p/QmPoHmYtUt8BU9eiwMYdBfT6rooBnna5fdAZHUaZASGQY8")
+        let peerID3 = try ma3.getPeerIDActual()
+
+        XCTAssertEqual(peerID3.type, .idOnly)
+
+        XCTAssertEqual(peerID1, peerID3)
+    }
+}


### PR DESCRIPTION
### What:
Added Interop tests between PeerID and Multiaddr

### Why:
- This is the first package in our stack that depends on these two libraries.
- This package will eventually implement and expose the updated `Multiaddr.getPeerID() -> PeerID` function once 
https://github.com/swift-libp2p/swift-multiaddr/issues/14 
is addressed.