### PR TITLE
Multiaddr Update

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -38,7 +38,7 @@ let package = Package(
         .package(url: "https://github.com/swift-libp2p/swift-peer-id.git", .upToNextMinor(from: "0.1.0")),
 
         // LibP2P Multiaddr
-        .package(url: "https://github.com/swift-libp2p/swift-multiaddr.git", .upToNextMinor(from: "0.0.1")),
+        .package(url: "https://github.com/swift-libp2p/swift-multiaddr.git", .upToNextMinor(from: "0.1.0")),
 
         // Logging
         .package(url: "https://github.com/apple/swift-log.git", .upToNextMajor(from: "1.0.0")),

--- a/Sources/LibP2PCore/Network/Connection.swift
+++ b/Sources/LibP2PCore/Network/Connection.swift
@@ -139,11 +139,7 @@ extension Connection {
     }
 
     public var expectedRemotePeer: PeerID? {
-        //print("LibP2PCore:Connection:ERROR: FIXME!!!")
-        if let cid = self.remoteAddr?.getPeerID() {
-            return try? PeerID(cid: cid)
-        }
-        return nil
+        try? self.remoteAddr?.getPeerID()
     }
 }
 

--- a/Sources/LibP2PCore/Peer/Peer.swift
+++ b/Sources/LibP2PCore/Peer/Peer.swift
@@ -34,6 +34,7 @@ import PeerID
 //    var addr:[Multiaddr] { get }
 //}
 
+/// A peer (PeerID) and their known addresses (Multiaddr)
 public struct PeerInfo {
     public let peer: PeerID
     public let addresses: [Multiaddr]
@@ -45,9 +46,10 @@ public struct PeerInfo {
 }
 
 extension Multiaddr {
-    // TODO: Rename this to getPeerID once https://github.com/swift-libp2p/swift-multiaddr/issues/14 is addressed
-    func getPeerIDActual() throws -> PeerID {
-        guard let cid = self.getPeerID() else {
+    /// Attempts to extract a PeerID from the Multiaddr if one is present
+    /// - Note: The returned PeerID is usually only an ID and doesn't contain a key pair. In some instances (ED25519 keys) a public key might be recoverable.
+    func getPeerID() throws -> PeerID {
+        guard let cid = self.getPeerIDString() else {
             throw NSError(domain: "No CID present in Multiaddr", code: 0)
         }
         return try PeerID(cid: cid)

--- a/Sources/LibP2PCore/Peer/Peer.swift
+++ b/Sources/LibP2PCore/Peer/Peer.swift
@@ -48,7 +48,7 @@ public struct PeerInfo {
 extension Multiaddr {
     /// Attempts to extract a PeerID from the Multiaddr if one is present
     /// - Note: The returned PeerID is usually only an ID and doesn't contain a key pair. In some instances (ED25519 keys) a public key might be recoverable.
-    func getPeerID() throws -> PeerID {
+    public func getPeerID() throws -> PeerID {
         guard let cid = self.getPeerIDString() else {
             throw NSError(domain: "No CID present in Multiaddr", code: 0)
         }

--- a/Tests/LibP2PCoreTests/MultiaddrPeerIDTests.swift
+++ b/Tests/LibP2PCoreTests/MultiaddrPeerIDTests.swift
@@ -24,46 +24,46 @@ final class MultiaddrPeerIDTests: XCTestCase {
     func testGetPeerID() throws {
         // B58 String
         let ma1 = try Multiaddr("/dnsaddr/bootstrap.libp2p.io/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN")
-        let peerID1 = try ma1.getPeerIDActual()
+        let peerID1 = try ma1.getPeerID()
 
         // B58 String
         let ma2 = try Multiaddr("/ip4/139.178.91.71/tcp/4001/p2p/QmNnooDu7bfjPFoTZYxMNLWUQJyrVwtbZg5gBMjTezGAJN")
-        let peerID2 = try ma2.getPeerIDActual()
+        let peerID2 = try ma2.getPeerID()
 
         // CID String
         let ma3 = try Multiaddr(
             "/dnsaddr/bootstrap.libp2p.io/p2p/bafzbeiagwnqiviaae5aet2zivwhhsorg75x2wka2pu55o7grr23ulx5kxm"
         )
-        let peerID3 = try ma3.getPeerIDActual()
+        let peerID3 = try ma3.getPeerID()
 
         XCTAssertEqual(peerID1, peerID2)
         XCTAssertEqual(peerID1, peerID3)
 
         // Embedded Public Key
         let ma4 = try Multiaddr("/dnsaddr/bootstrap.libp2p.io/p2p/12D3KooWAfPDpPRRRBrmqy9is2zjU5srQ4hKuZitiGmh4NTTpS2d")
-        let peerID4 = try ma4.getPeerIDActual()
+        let peerID4 = try ma4.getPeerID()
 
         XCTAssertEqual(peerID4.type, .isPublic)
 
         // Throw when no PeerID is present
-        XCTAssertThrowsError(try Multiaddr("/dnsaddr/bootstrap.libp2p.io/").getPeerIDActual())
+        XCTAssertThrowsError(try Multiaddr("/dnsaddr/bootstrap.libp2p.io/").getPeerID())
     }
 
     func testGetPeerIDEmbeddedEd25519PublicKey() throws {
         let ma1 = try Multiaddr("/dnsaddr/bootstrap.libp2p.io/p2p/12D3KooWAfPDpPRRRBrmqy9is2zjU5srQ4hKuZitiGmh4NTTpS2d")
 
-        let embeddedKeyInBytes = try BaseEncoding.decode(ma1.getPeerID()!, as: .base58btc)
+        let embeddedKeyInBytes = try BaseEncoding.decode(ma1.getPeerIDString()!, as: .base58btc)
         let peerID1 = try PeerID(fromBytesID: embeddedKeyInBytes.data.bytes)
 
         let ma2 = try Multiaddr("/dnsaddr/bootstrap.libp2p.io/p2p/12D3KooWAfPDpPRRRBrmqy9is2zjU5srQ4hKuZitiGmh4NTTpS2d")
-        let peerID2 = try ma2.getPeerIDActual()
+        let peerID2 = try ma2.getPeerID()
 
         XCTAssertEqual(peerID1, peerID2)
         XCTAssertEqual(peerID1.type, .isPublic)
         XCTAssertEqual(peerID2.type, .isPublic)
 
         let ma3 = try Multiaddr("/ip4/139.178.91.71/tcp/4001/p2p/QmPoHmYtUt8BU9eiwMYdBfT6rooBnna5fdAZHUaZASGQY8")
-        let peerID3 = try ma3.getPeerIDActual()
+        let peerID3 = try ma3.getPeerID()
 
         XCTAssertEqual(peerID3.type, .idOnly)
 


### PR DESCRIPTION
### What:
- Updated `getPeerID` to support the latest `Multiaddr` release
https://github.com/swift-libp2p/swift-multiaddr/releases/tag/0.1.0

### Why:
- https://github.com/swift-libp2p/swift-multiaddr/issues/14

### Breaking Changes
```swift
// From
Multiaddr.getPeerID() -> String?

// To
Multiaddr.getPeerID() throws -> PeerID
```